### PR TITLE
feat(handlers): add rotating proxies download handler

### DIFF
--- a/src/helpers/handlers/__init__.py
+++ b/src/helpers/handlers/__init__.py
@@ -1,0 +1,1 @@
+from .rotating_proxies_download_handler import RotatingProxiesDownloadHandler

--- a/src/helpers/handlers/rotating_proxies_download_handler.py
+++ b/src/helpers/handlers/rotating_proxies_download_handler.py
@@ -1,0 +1,11 @@
+from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
+from scrapy.utils import reactor
+from twisted.web.client import HTTPConnectionPool
+
+
+class RotatingProxiesDownloadHandler(HTTPDownloadHandler):
+    def __init__(self, settings, crawler=None):
+        super(RotatingProxiesDownloadHandler, self).__init__(settings, crawler)
+        self._pool = HTTPConnectionPool(reactor, persistent=False)
+        self._pool.maxPersistentPerHost = settings.getint("CONCURRENT_REQUESTS_PER_DOMAIN")
+        self._pool._factory.noisy = False


### PR DESCRIPTION
На сейчас ip адреса StormProxy не меняются для домена при использовании их из scrapy(фиксируется первый полученный ip адрес и дальше все запросы на домен идут с него). Подключение этого DOWNLOAD_HANDLER исправляет ситуацию.

Пример:

```
import re
import scrapy

class IpSpider(scrapy.Spider):
    name = 'ip'
    custom_settings = {
        'CONCURRENT_REQUESTS': 4,
        'DOWNLOAD_TIMEOUT': 4,
        'RETRY_TIMES': 2,
        'COOKIES_ENABLED': False,
        'LOG_LEVEL': 'INFO',
        "DOWNLOAD_HANDLERS": {
            'http': 'helpers.handlers.RotatingProxiesDownloadHandler',
            'https': 'helpers.handlers.RotatingProxiesDownloadHandler'
        },
        'DOWNLOADER_MIDDLEWARES': {
            "middlewares.HttpProxyMiddleware": 543,
        }
    }

    def start_requests(self):
        for i in range(10):
            yield scrapy.Request('https://api.myip.com', self.parse, dont_filter=True)
            yield scrapy.Request('https://httpbin.org/ip?q=', self.parse, dont_filter=True)
            yield scrapy.Request('https://httpbin.org/ip', self.parse, dont_filter=True)

    def parse(self, response):
        self.logger.info('{} {}'.format(response.url, re.sub(r'\s+', '', response.text)))
```