### PR TITLE
feat(rmq): fix errback method for rmq module

### DIFF
--- a/src/rmq/utils/__init__.py
+++ b/src/rmq/utils/__init__.py
@@ -1,4 +1,5 @@
 from .constants import RMQConstants
+from .extract_delivery_tag_from_failure import extract_delivery_tag_from_failure
 from .import_full_name import get_import_full_name
 from .rmq_default_options import RMQDefaultOptions
 from .task import Task

--- a/src/rmq/utils/extract_delivery_tag_from_failure.py
+++ b/src/rmq/utils/extract_delivery_tag_from_failure.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from scrapy import Request
+from scrapy.http import Response
+from twisted.python.failure import Failure
+
+
+def extract_delivery_tag_from_failure(failure: Failure) -> Optional[int]:
+    if hasattr(failure, "request") and isinstance(failure.request, Request):
+        return failure.request.meta.get("delivery_tag")
+    elif hasattr(failure, "response") and isinstance(failure.response, Response):
+        return failure.response.meta.get("delivery_tag")
+    elif hasattr(failure.value, "request") and isinstance(failure.value.request, Request):
+        return failure.value.request.meta.get("delivery_tag")
+    elif hasattr(failure.value, "response") and isinstance(failure.value.response, Response):
+        return failure.value.response.meta.get("delivery_tag")
+    elif hasattr(failure.value, "meta"):
+        return failure.value.meta.get("delivery_tag")
+
+    return None


### PR DESCRIPTION
При попадании на errback не происходит ack/nack сообщения, ошибка из https://github.com/groupbwt/scrapy-boilerplate/issues/46#issuecomment-664037046. Мерж должен это исправить.

Минимальный пример для воссоздания ошибки (нужно добавить произвольное сообщение в errback_task для запуска). Без мержа паук зависает при получении ошибок в количестве CONCURRENT_REQUESTS.

```
import scrapy

from rmq.items import RMQItem
from rmq.pipelines import ItemProducerPipeline
from rmq.spiders import TaskToSingleResultSpider
from rmq.utils import get_import_full_name
from rmq.utils.decorators import rmq_callback, rmq_errback


class ErrbackSpider(TaskToSingleResultSpider):
    name = 'errback'

    custom_settings = {
        'LOG_LEVEL': 'DEBUG',
        'DOWNLOAD_TIMEOUT': 0.001,
        'RETRY_TIMES': 2,
        "ITEM_PIPELINES": {
            get_import_full_name(ItemProducerPipeline): 310,
        },
    }

    def start_requests(self):
        yield from ()

    def __init__(self, *args, **kwargs):
        super(ErrbackSpider, self).__init__(*args, **kwargs)
        self.task_queue_name = 'errback_task'
        self.result_queue_name = 'errback_result'

    def next_request(self, _delivery_tag: int, msg_body: bytes):
        return scrapy.Request(
            'https://httpstat.us/200',
            callback=self.parse,
            dont_filter=True,
            errback=self.errback,
        )

    @rmq_callback
    def parse(self, response):
        yield RMQItem()
        self.logger.info('parse')

    @rmq_errback
    def errback(self, failure):
        yield RMQItem()
        yield RMQItem()
        self.logger.info('errback')

```