### PR TITLE
update rotating proxies handler

### DIFF
--- a/src/python/src/helpers/handlers/rotating_proxies_download_handler.py
+++ b/src/python/src/helpers/handlers/rotating_proxies_download_handler.py
@@ -1,11 +1,29 @@
+import logging
+
+from scrapy import Spider, Request
 from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
-from scrapy.utils import reactor
-from twisted.web.client import HTTPConnectionPool
+
+
+# custom_settings = {
+#     "DOWNLOAD_HANDLERS": {
+#         'http': 'website_monitoring.handlers.RotatingProxiesDownloadHandler',
+#         'https': 'website_monitoring.handlers.RotatingProxiesDownloadHandler'
+#     },
+#     'ROTATING_PROXIES_DOWNLOADER_HANDLER_AUTO_CLOSE_CACHED_CONNECTIONS_ENABLED': False,
+# }
 
 
 class RotatingProxiesDownloadHandler(HTTPDownloadHandler):
-    def __init__(self, settings, crawler=None):
-        super(RotatingProxiesDownloadHandler, self).__init__(settings, crawler)
-        self._pool = HTTPConnectionPool(reactor, persistent=False)
-        self._pool.maxPersistentPerHost = settings.getint("CONCURRENT_REQUESTS_PER_DOMAIN")
-        self._pool._factory.noisy = False
+    logger = logging.getLogger(name=__name__)
+
+    def download_request(self, request: Request, spider: Spider):
+        """Return a deferred for the HTTP download"""
+        if (
+            spider.settings.get('ROTATING_PROXIES_DOWNLOADER_HANDLER_AUTO_CLOSE_CACHED_CONNECTIONS_ENABLED') or
+            request.meta.get('close_cached_connections')
+        ):
+            if request.meta.get('close_cached_connections'):
+                self.logger.debug('close cached connections')
+            self._pool.closeCachedConnections()
+
+        return super().download_request(request, spider)

--- a/src/python/src/helpers/handlers/rotating_proxies_download_handler.py
+++ b/src/python/src/helpers/handlers/rotating_proxies_download_handler.py
@@ -6,8 +6,8 @@ from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 
 # custom_settings = {
 #     "DOWNLOAD_HANDLERS": {
-#         'http': 'website_monitoring.handlers.RotatingProxiesDownloadHandler',
-#         'https': 'website_monitoring.handlers.RotatingProxiesDownloadHandler'
+#         'http': 'helpers.handlers.RotatingProxiesDownloadHandler',
+#         'https': 'helpers.handlers.RotatingProxiesDownloadHandler'
 #     },
 #     'ROTATING_PROXIES_DOWNLOADER_HANDLER_AUTO_CLOSE_CACHED_CONNECTIONS_ENABLED': False,
 # }

--- a/src/python/src/settings.py
+++ b/src/python/src/settings.py
@@ -19,8 +19,7 @@ PROXY_AUTH = os.getenv("PROXY_AUTH", "")
 PROXY_ENABLED = strtobool(os.getenv("PROXY_ENABLED", "False"))
 
 USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/73.0.3683.103 Safari/537.36"
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
 )
 
 CONCURRENT_REQUESTS = int(os.getenv("CONCURRENT_REQUESTS", "16"))
@@ -39,6 +38,8 @@ DEFAULT_REQUEST_HEADERS = {
     "Accept-Language": "en-US,en;q=0.5",
     "Cache-Control": "max-age=0",
 }
+
+ROTATING_PROXIES_DOWNLOADER_HANDLER_AUTO_CLOSE_CACHED_CONNECTIONS_ENABLED: bool = True
 
 DOWNLOADER_MIDDLEWARES = {
     "scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware": None,


### PR DESCRIPTION
Старый вариант класса делал соединение не постоянным из-за чего:
- запросы на некоторые порталы не проходили
- время парсинга увеличивалось, т.к. за каждой попыткой открывалось новое соединение

В текущем варианте соединене постоянное, прокси меняектся при получении **close_cached_connections** meta параметра.
