### PR TITLE
feat(rmq pipeline): add push possibility  to different queue

### DIFF
--- a/src/python/src/rmq/pipelines/item_producer_pipeline.py
+++ b/src/python/src/rmq/pipelines/item_producer_pipeline.py
@@ -49,9 +49,9 @@ class ItemProducerPipeline:
         self.__spider = spider
 
         """Check spider for correct declared callbacks/errbacks/methods/variables"""
-        if self._validate_spider_has_attributes() is False:
+        if not self._is_spider_has_required_methods():
             raise CloseSpider(
-                "Attached spider has no configured task_queue_name and processing_tasks observer"
+                "Attached spider has no configured get_result_queue_name"
             )
 
         """Configure loggers"""
@@ -59,7 +59,11 @@ class ItemProducerPipeline:
         logging.getLogger("pika").setLevel(self.__spider.settings.get("PIKA_LOG_LEVEL", "WARNING"))
 
         """Declare/retrieve queue name from spider instance"""
-        result_queue_name = spider.result_queue_name
+        result_queue_name = self._get_result_queue_name()
+        if not isinstance(result_queue_name, str) or len(result_queue_name) == 0:
+            raise CloseSpider(
+                f"Invalid result queue name: {result_queue_name}"
+            )
 
         """Build pika connection parameters and start connection in separate twisted thread"""
         parameters = pika.ConnectionParameters(
@@ -87,16 +91,11 @@ class ItemProducerPipeline:
                     self.rmq_connection.stop
                 )
 
-    def _validate_spider_has_attributes(self):
-        spider_attributes = [
-            attr for attr in dir(self.__spider) if not callable(getattr(self.__spider, attr))
+    def _is_spider_has_required_methods(self):
+        spider_methods = [
+            attr for attr in dir(self.__spider) if callable(getattr(self.__spider, attr))
         ]
-        if "result_queue_name" not in spider_attributes:
-            return False
-        if (
-            not isinstance(self.__spider.result_queue_name, str)
-            or len(self.__spider.result_queue_name) == 0
-        ):
+        if "get_result_queue_name" not in spider_methods:
             return False
         return True
 
@@ -134,9 +133,19 @@ class ItemProducerPipeline:
             if self.delivery_tag_meta_key in item_as_dictionary:
                 del item_as_dictionary[self.delivery_tag_meta_key]
             cb = functools.partial(
-                self.rmq_connection.publish_message, message=json.dumps(item_as_dictionary)
+                self.rmq_connection.publish_message,
+                queue_name=self.choose_queue_name(item),
+                message=json.dumps(item_as_dictionary)
             )
             self.rmq_connection.connection.ioloop.add_callback_threadsafe(cb)
+
+    def choose_queue_name(self, item):
+        if isinstance(item, RMQItem):
+            return self.__spider.get_result_queue_name()
+        else:
+            raise NotImplementedError(
+                f"Method choose_queue_name must be overriding, because got unexpected item type: {type(item)}"
+            )
 
     def process_item(self, item, spider):
         """Invoked when item is processed"""
@@ -148,3 +157,6 @@ class ItemProducerPipeline:
             else:
                 self.pending_items_buffer.append(item)
         return item
+
+    def _get_result_queue_name(self) -> str:
+        return self.__spider.get_result_queue_name()

--- a/src/python/src/rmq/pipelines/item_producer_pipeline.py
+++ b/src/python/src/rmq/pipelines/item_producer_pipeline.py
@@ -134,14 +134,14 @@ class ItemProducerPipeline:
                 del item_as_dictionary[self.delivery_tag_meta_key]
             cb = functools.partial(
                 self.rmq_connection.publish_message,
-                queue_name=self.choose_queue_name(item),
+                queue_name=self.choose_queue_name(item, self.__spider),
                 message=json.dumps(item_as_dictionary)
             )
             self.rmq_connection.connection.ioloop.add_callback_threadsafe(cb)
 
-    def choose_queue_name(self, item):
+    def choose_queue_name(self, item, spider):
         if isinstance(item, RMQItem):
-            return self.__spider.get_result_queue_name()
+            return spider.get_result_queue_name()
         else:
             raise NotImplementedError(
                 f"Method choose_queue_name must be overriding, because got unexpected item type: {type(item)}"


### PR DESCRIPTION
### Changelog:

1. Добавил возможность выбора очереди, в которую будет пушиться RMQItem через ItemProducerPipeline. Предполагается, что очередь будет выбираться на основе подклассов RMQItem-a. Необходимо унаследоваться от ItemProducerPipeline  и переопределить метод choose_queue_name. По умолчанию будет использоваться очередь, которая будет возвращена методом get_result_queue_name.
2. Удалил атрибут result_queue_name, и его валидацию. Добавил вместо него метод get_result_queue_name и валидацию его аутпута. В основном, имя очереди берется из настроек проекта settings.py. Сейчас есть 2 способа в пауке установить имя очереди:
2.1.  Импортировать функцию get_project_settings из scrapy.utils.project, вызвать её, и уже после получить доступ к имени очереди. Считаю такой подход не лучшим, из-за неочевидности и из-за возможных потенциальных ошибок, так как settings могут быть перегружены в пауке.
2.2. В класс методе from_crawler, создать экземпляр класса паука, получить доступ к его settings и присвоить этому экземпляру метод result_queue_name из settings. Считаю этот способ слишком грамоздким.
### Example usage
Паук должен переопределить метод get_result_queue_name, который должен возвращать имя очереди типа str. В нем сразу доступны настройки паука через экземпляр класса.

>     def get_result_queue_name(self)->str:
>           return self.settings["RESULT_QUEUE_NAME"]

Пример использования pipeline-a  для нескольких очередей.

> class TestPipeline(ItemProducerPipeline):
>
>     def choose_queue_name(self, item):
>         if isinstance(item, TestItem1):
>             return "results_test1"
>         elif isinstance(item, TestItem2):
>             return self.__spider.settings["results_test2"]

### Futher features
В идеале разделить логику для пауков:

1. TaskToSingleResultSpider - необходим метод get_result_queue_name, который возвращает имя единственной очереди.
2. TaskToMultipleResultsSpider - метод get_result_queue_name игнорируется(не нуждается в переопределении), вместо него требуется переопределить в пайплайне метод choose_queue_name, и указать в нем несколько очередей как в примере example usage. Сейчас это невозможно, так как при старте PikaSelectConnection декларирует всегда очередь, и get_result_queue_name переопределять все равно необходимо.