### PR TITLE
- feat(middlewares): added middleware what allow spiders to forward meta from response to request;

### DIFF
--- a/src/python/src/middlewares/__init__.py
+++ b/src/python/src/middlewares/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from .http_proxy_middleware import HttpProxyMiddleware
+from .forward_meta_middleware import ForwardMetaMiddleware

--- a/src/python/src/middlewares/forward_meta_middleware.py
+++ b/src/python/src/middlewares/forward_meta_middleware.py
@@ -1,0 +1,43 @@
+from scrapy import Spider, Request, Spider, signals
+from scrapy.http import Response
+
+
+class ForwardMetaMiddleware:
+    """This middleware allows spiders to forward meta from response to request
+
+    spider:
+        Change service fields list:
+            meta_service_fields = []
+    """
+
+    def __init__(self):
+        self.last_meta = None
+        self.service_fields = [
+            'download_timeout',
+            'download_slot',
+            'download_latency',
+            'retry_times',
+            'depth'
+            ]
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        o = cls()
+        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        return o
+
+    def spider_opened(self, spider: Spider):
+        self.service_fields = getattr(spider, 'meta_service_fields', self.service_fields)
+
+    def process_request(self, request: Request, spider: Spider):
+        if self.last_meta:
+            spider.logger.warning(f'self.last_meta {self.last_meta}')
+            request.meta.update(self.last_meta)
+
+    def process_response(self, request: Request, response: Response, spider: Spider):
+        meta: dict = getattr(request, "meta", {})
+
+        if meta:
+            values = [(k, v) for k, v in meta.items() if k not in self.service_fields]
+            self.last_meta = dict(values)
+        return response


### PR DESCRIPTION
- Added ForwardMetaMiddleware middleware;
- Middleware transfers meta data from the response to the meta request;
- The service_fields change, which stores the fields that will not roll over, can be redefined in the spider through the meta_service_fields change;